### PR TITLE
Added libproj-dev and enabled pigpio service

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -298,7 +298,7 @@ EOM
 }
 
 function configure_ros() {
-    chroot $R apt-get -y install python-rosinstall python-wstool
+    chroot $R apt-get -y install python-rosinstall python-wstool libproj-dev
     chroot $R rosdep init
     # Overlay that has our custom dependencies
     cat <<EOM >$R/etc/ros/rosdep/sources.list.d/30-ubiquity.list
@@ -598,6 +598,9 @@ function install_software() {
     python-picamera python3-picamera \
     python-rtimulib python3-rtimulib \
     python-pygame
+    
+    #enable pigpio daemon
+    chroot $R systemctl enable pigpiod
 
     chroot $R pip2 install codebug_tether
     chroot $R pip3 install codebug_tether


### PR DESCRIPTION
So apparently there's [an issue](https://github.com/UbiquityRobotics/pi_sonar/issues/13) where the latest image doesn't have pigpio daemon enabled by default so the sonar node doesn't run. At the moment enabling the service seemingly fixes it for me but we should wait for @mjstn to recheck.

There's also another thing, it would seem that some of the nav branches of move_basic fail at compilation (some weird recipe target failed thing) which can be apparently fixed by installing libproj-dev. Not sure why exactly but it should help us and other people from running into this hard to debug error.