### PR TITLE
added optional logclean line

### DIFF
--- a/files/magni-base.sh
+++ b/files/magni-base.sh
@@ -23,6 +23,9 @@ if [[ ! -d $log_path ]]; then
   fi
 fi
 
+# uncomment this if you want ros log cleanup enabled on boot 
+#source $(rospack find magni_bringup)"/scripts/ros_log_clean.bash"
+
 source /etc/ubiquity/env.sh
 log info "magni-base: Launching ROS_HOSTNAME=$ROS_HOSTNAME, ROS_IP=$ROS_IP, ROS_MASTER_URI=$ROS_MASTER_URI, ROS_LOG_DIR=$log_path"
 


### PR DESCRIPTION
@MoffKalast suggested we add a README of some sort on the home directory to notify the user there is an option to uncomment logclean in magni-base.sh. Should we add that and how do we do it? Maybe just adding into the README of the magni_robot repo or this repo would be enough?