### PR TITLE
Feature camextr demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ You may want to use a different RTC by changing the line `dtoverlay=i2c-rtc,mcp7
 The systemd service `hwclock-sync` is responsible for syncing the system clock with the RTC on first boot, if you don't have an RTC you may wish to disable it.
 
 `systemctl disable hwclock-sync.service`
+
+## System files placement
+
+ - `robot.yaml` should be inside `/etc/ubiquity/robot.yaml`
+ - `extrinsics_demo.yaml` should be inside `.ros/camera_info/extrinsics_demo.yaml`
+ - `pifi.conf` should be inside `/etc/pifi/pifi.conf`
+ - `magni-base.sh` should be inside `/usr/sbin/magni-base`
+ - TODO where should other system files be?

--- a/files/extrinsics_demo.yaml
+++ b/files/extrinsics_demo.yaml
@@ -1,0 +1,15 @@
+# in order to set the camera extrinsics with this yaml, it  should be placed inside 
+# .ros/camera_info/extrinsics_demo.yaml, then  "raspicam: {'position' : 'demo'}" 
+# should be placed inside /etc/ubiquity/robot.yaml
+
+# position of the camera x, y, z
+position:
+  - 0.0
+  - 0.0
+  - 0.0
+
+# orientation of the camera x, y, z
+orientation:
+  - 0.0
+  - 0.0
+  - 0.0


### PR DESCRIPTION
Added the tested `extrinsics_demo.yaml` (and instructions how to use it inside in the comments) because a lot of people dont know how it should look like and i think it would help to explain that. - it is disabled by default anyway because `robot.yaml` still has raspicam: `{'position' : 'upward'}` by default

I also think adding exact system file placement to README would also help explaining where everything is - this list should still be completed before merging, can anyone help with that @rohbotics @MoffKalast ?